### PR TITLE
Added Open Collective Chapter Definition to Glossary

### DIFF
--- a/about/glossary.md
+++ b/about/glossary.md
@@ -38,3 +38,6 @@ Admins of [Fiscal Hosts](../hosts/) manage the entities that provide the bank ac
 
 Attendees are users who register to a Collective's event. They often arrive through a direct link provided by the event organizers. They want a smooth, hassle-free experience, clear information about the event, and ideally a pathway to stay in touch or become Backers.
 
+### Open Collective Chapter
+
+An Open Collective Chapter is a regional or topical version of Open Collective. For example, we have [Open Collective Paris](https://opencollective.com/paris) that is dedicated to foster an ecosystem of open collectives in Paris. We also have the [Open Source Collective](https://opencollective.com/opensource) that enables open collectives for open source communities all around the world.


### PR DESCRIPTION
I wanted to know more about the Open Collective Chapters but could not find any description of it in the glossary, so I added the definition from https://opencollective.com/chapters to the glossary.

Below is a screenshot:
![image](https://user-images.githubusercontent.com/30334776/57127225-96d40280-6d87-11e9-91f2-40d65d99eb70.png)
