### PR TITLE
about/company: Update link

### DIFF
--- a/about/company.md
+++ b/about/company.md
@@ -16,7 +16,7 @@ Our team is distributed between New York, Guadalajara, Paris, Brussels, Berlin, 
 
 ### Can I see your company budget?
 
-We run our company via [multiple Open Collectives](https://opencollective.com/opencollectiveinc) ourselves. You can also see the [Collective for the Open Source Collective](https://opencollective.com/opensource). We still have some work to do to be even more transparent, and we hope to continue improving in this area.
+We run our company via [multiple Open Collectives](https://opencollective.com/opencollective) ourselves. You can also see the [Collective for the Open Source Collective](https://opencollective.com/opensource). We still have some work to do to be even more transparent, and we hope to continue improving in this area.
 
 ### How much investment have you raised?
 


### PR DESCRIPTION
There's currently a link in About/Company which leads to https://opencollective.com/opencollectiveinc , but that page doesn't seem to exist any more:
![Screenshot from 2021-01-07 15-00-12](https://user-images.githubusercontent.com/43905913/103895945-dd9c0300-50f9-11eb-9065-0a5a03d1649f.png)

This PR changes that link to https://opencollective.com/opencollective