### PR TITLE
Removes host admin creation instruction

### DIFF
--- a/contributing/development/testing-with-cypress.md
+++ b/contributing/development/testing-with-cypress.md
@@ -32,7 +32,7 @@ Both the `cy.login` and `cy.signup` commands accept a redirect parameter. You ca
 
 Login with an existing account. If not provided in `params`, the email used for authentication will be `testuser+admin@opencollective.com`.
 
-Note that addresses formatted like `test*@opencollective.com` are a special case that let you login directly without the need to confirm your email. You can use the `randomEmail` helper to generate these. If you want to specifically create a host admin user please use, `test*+host@opencollective.com` \(i.e: the email should end with `host@opencollective.com`\).
+Note that addresses formatted like `test*@opencollective.com` are a special case that let you login directly without the need to confirm your email. You can use the `randomEmail` helper to generate these.
 
 {% hint style="info" %}
 **`cy.signup({user, redirect} = params)`**


### PR DESCRIPTION
This is no longer valid as we have removed this user creation on the api side as per, https://github.com/opencollective/opencollective-api/pull/5402#discussion_r618355511

Related to https://github.com/opencollective/documentation/pull/103