### PR TITLE
Update CodeFund -> EthicalAds

### DIFF
--- a/collectives/funding-options.md
+++ b/collectives/funding-options.md
@@ -10,7 +10,7 @@ Check with your [Fiscal Host](../fiscal-hosts/fiscal-hosts.md) to see if these o
 
 ## Ethical Advertising
 
-Speaking to niche audiences, like developers, in their own environment is one way OSS can leverage the tangible value it provides companies. Examples include CodeFund, Carbon Ads or referral fee solutions like Triplebyte.
+Speaking to niche audiences, like developers, in their own environment is one way OSS can leverage the tangible value it provides companies. Examples include [EthicalAds](https://www.ethicalads.io/), Carbon Ads, or referral fee solutions like Triplebyte.
 
 We [wrote a blog post](https://medium.com/open-collective/using-ads-to-sustain-open-source-d048b75d4979) about this if you want to know more.
 


### PR DESCRIPTION
We're doing what CodeFund used to do: https://www.ethicalads.io/blog/2020/08/announcing-ethicalads/

I'd love to see the blog post updated with this as well, if possible: https://medium.com/open-collective/using-ads-to-sustain-open-source-d048b75d4979