### PR TITLE
Increase visibility for paypal information

### DIFF
--- a/independent-collectives/set-up-independent-collective.md
+++ b/independent-collectives/set-up-independent-collective.md
@@ -20,9 +20,10 @@ In the Info section, you'll see a field for 'address'. This is used on receipts 
 
 To enable people to contribute to your Collective, you need to set up ways that they can pay you. On this screen you can connect your Stripe account for credit card payments and/or add the details for bank transfers.
 
+{% hint style="info" %} If you wish to receive money via PayPal, please [contact support](mailto:support@opencollective.com) as this feature is still in beta. {% endhint %}
+
 ![](../.gitbook/assets/screen-shot-2021-09-30-at-2.43.14-pm.png)
 
-If you wish to receive money via PayPal, please [contact support](mailto:support@opencollective.com) as this feature is still in beta.
 
 ## Sending Money
 


### PR DESCRIPTION
Rearranges and increases the visibility of the Paypal information in regards to receiving money.

Previously, with the information present at the end of the section, it was easy to get visually lost below the fold. Bringing it above the screenshot and using a hint to visually distinguish it helps make sure it is seen by users.

![image](https://user-images.githubusercontent.com/1479909/157499206-12fed56a-fa3e-4a15-aa18-b7e3dc9caeac.png)
