### PR TITLE
Add info about uploading receipts to transactions

### DIFF
--- a/collectives/collective-settings/core-contributors.md
+++ b/collectives/collective-settings/core-contributors.md
@@ -6,9 +6,9 @@ With the implementation of the new [Dashboard interface](https://docs.opencollec
 
 ## Roles
 
-**Admins** have full permissions to change settings, approve expenses, and make financial contributions from the budget balance.
+**Admins** have full permissions to change settings, approve expenses, add receipts to transactions and make financial contributions from the budget balance.
 
-**Core contributors** show up in the Team section of your page and can create events, but can't change settings or approve expenses.
+**Core contributors** show up in the Team section of your page and can create events, but can't change settings, add receipts or approve expenses.
 
 **Accountants** can access financial information, such as receipts, invoices, and reports. They can't change settings or approve expenses.
 


### PR DESCRIPTION
Just a small change but I wasn't able to find out what permissions were required for someone to be able to add receipts to transactions. I'd have thought an accountant could do that but apparently full admin is needed (guess it's editing a transaction).