### PR TITLE
Update OAuth documentation based on recent changes

### DIFF
--- a/developers/oauth.md
+++ b/developers/oauth.md
@@ -6,6 +6,8 @@ description: >-
 
 # OAuth
 
+OpenCollective implements the standard OAuth 2.0 [Authorization Code Grant Flow](https://oauth.net/2/grant-types/authorization-code/). Additionally, we support [PKCE](https://oauth.net/2/pkce/) for the Authorization Code Grant Flow, which is recommended to prevent theft of the authorization code by intermediaries, malicious scripts, or browser extensions.
+
 ## Creating an OAuth app
 
 1. Go to `https://opencollective.com/{account}/admin/for-developers` (replace `{account}` by the slug of the account you want to use as the owner of the app)
@@ -31,7 +33,7 @@ The web application flow to authorize users for your app is:
 
 #### **Parameters**
 
-<table><thead><tr><th width="150">Name</th><th width="150">Type</th><th>Description</th></tr></thead><tbody><tr><td><code>client_id</code></td><td>string</td><td><strong>Required.</strong> The client ID you copied after <a href="oauth.md#creating-an-oauth-app">creating your app</a>.</td></tr><tr><td><code>response_type</code></td><td>string</td><td><strong>Required.</strong> Only supported value for now is <code>code</code></td></tr><tr><td><code>redirect_uri</code></td><td>string</td><td>The URL in your application where users will be sent after authorization. If left out, Open Collective will redirect users to the callback URL configured in the OAuth Application settings. If provided, the redirect URL's host and port must exactly match the callback URL.</td></tr><tr><td><code>scope</code></td><td>string</td><td>A comma-separated list of scopes. If not provided, <code>scope</code> defaults to an empty list.</td></tr><tr><td><code>state</code></td><td>string</td><td>Use it to pass some state back to your application after redirecting and to protect against cross-site request forgery attacks (CSRF) by including an unguessable random string. See <a href="oauth.md#scopes-for-oauth-apps">scopes below</a>.</td></tr></tbody></table>
+<table><thead><tr><th width="150">Name</th><th width="150">Type</th><th>Description</th></tr></thead><tbody><tr><td><code>client_id</code></td><td>string</td><td><strong>Required.</strong> The client ID you copied after <a href="oauth.md#creating-an-oauth-app">creating your app</a>.</td></tr><tr><td><code>response_type</code></td><td>string</td><td><strong>Required.</strong> Only supported value for now is <code>code</code></td></tr><tr><td><code>redirect_uri</code></td><td>string</td><td>The URL in your application where users will be sent after authorization. If left out, Open Collective will redirect users to the callback URL configured in the OAuth Application settings. If provided, the redirect URL's host and port must exactly match the callback URL.</td></tr><tr><td><code>scope</code></td><td>string</td><td>A comma (legacy) or space separated list of scopes. If not provided, <code>scope</code> defaults to an empty list. See <a href="oauth.md#scopes-for-oauth-apps">scopes below</a>.</td></tr><tr><td><code>state</code></td><td>string</td><td>Use it to pass some state back to your application after redirecting and to protect against cross-site request forgery attacks (CSRF) by including an unguessable random string.</td></tr><tr><td><code>code_challenge</code></td><td>string</td><td>The code challenge value when using PKCE.</td></tr><tr><td><code>code_challenge_method</code></td><td>string</td><td>The code challenge method when using PKCE. The only valid value is <code>S256</code>.</td></tr></tbody></table>
 
 ### 2. Users are redirected back to your site
 
@@ -43,7 +45,7 @@ Otherwise, you can exchange the `code` you received as a parameter for an access
 
 #### Parameters
 
-<table><thead><tr><th width="150">Parameter</th><th width="150">Type</th><th>Description</th></tr></thead><tbody><tr><td><code>grant_type</code></td><td>string</td><td><strong>Required.</strong> The only supported value for now is <code>authorization_code</code></td></tr><tr><td><code>client_id</code></td><td>string</td><td><strong>Required.</strong> The client ID of your OAuth application (from <a href="oauth.md#creating-an-oauth-app">Creating an OAuth App</a>)</td></tr><tr><td><code>client_secret</code></td><td>string</td><td><strong>Required.</strong> The client secret of you OAuth application (from <a href="oauth.md#creating-an-oauth-app">Creating an OAuth App</a>)</td></tr><tr><td><code>code</code></td><td>string</td><td><strong>Required.</strong> The code you received as a response to <a href="oauth.md#1.-request-a-users-open-collective-identity">Step 1</a>, after the redirect)</td></tr><tr><td><code>redirect_uri</code></td><td>string</td><td><strong>Required.</strong> The URL in your application where users are sent after authorization.</td></tr></tbody></table>
+<table><thead><tr><th width="150">Parameter</th><th width="150">Type</th><th>Description</th></tr></thead><tbody><tr><td><code>grant_type</code></td><td>string</td><td><strong>Required.</strong> The only supported value for now is <code>authorization_code</code></td></tr><tr><td><code>client_id</code></td><td>string</td><td><strong>Required.</strong> The client ID of your OAuth application (from <a href="oauth.md#creating-an-oauth-app">Creating an OAuth App</a>)</td></tr><tr><td><code>client_secret</code></td><td>string</td><td><strong>Required.</strong> The client secret of you OAuth application (from <a href="oauth.md#creating-an-oauth-app">Creating an OAuth App</a>)</td></tr><tr><td><code>code</code></td><td>string</td><td><strong>Required.</strong> The code you received as a response to <a href="oauth.md#1.-request-a-users-open-collective-identity">Step 1</a>, after the redirect)</td></tr><tr><td><code>redirect_uri</code></td><td>string</td><td><strong>Required.</strong> The URL in your application where users are sent after authorization.</td></tr><tr><td><code>code_verifier</code></td><td>string</td><td>The code verifier when using PKCE.</td></tr></tbody></table>
 
 #### Response
 
@@ -51,11 +53,13 @@ If the request succeeds, you'll receive an HTTP 200 response code with a JSON pa
 
 ```json
 {
-  "access_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  "access_token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+  "token_type": "bearer",
+  "expires_in": 7776000
 }
 ```
 
-This `access_token` is what you want to use to access the API.
+This `access_token` is what you want to use to access the API. The `expires_in` property is the number of seconds for which the access token is valid for, currently this is always 90 days from the creation of the access token.
 
 ### 3. Use the access token to access the API
 


### PR DESCRIPTION
This incorporates the changes to correctly implement PKCE support: https://github.com/opencollective/opencollective/issues/7996

Additionally the `scope` value is now documented inline with https://github.com/opencollective/opencollective-frontend/pull/11344 (standard space separated scopes, whilst comma separated is still supported).

The token response has also been updated to reflect the `expires_in` and `token_type` properties.

I went with not fully explaining PKCE because it's kind of involved, and the link at the top of the documentation has resources to learn more about it.